### PR TITLE
Refactor: Enhance GitHub Repository Display and Filters

### DIFF
--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -154,8 +154,7 @@ const RepositoryCard = ({
         <div className="mt-2">
           <h4 className="text-sm font-semibold mb-1">Analysis</h4>
           <p className="text-xs text-gray-600 line-clamp-4">
-            {repository.analysis ||
-              `This ${repository.language || ""} repository has gained ${formatNumber(repository.stars)} stars and been forked ${formatNumber(repository.forks)} times.`}
+            {`Created on ${formatDate(repository.created_at)}. This ${repository.language || ""} repository has gained ${formatNumber(repository.stars)} stars and been forked ${formatNumber(repository.forks)} times. ${repository.analysis || ""}`}
           </p>
         </div>
       </CardContent>

--- a/src/components/RepositoryGrid.tsx
+++ b/src/components/RepositoryGrid.tsx
@@ -19,6 +19,7 @@ interface Repository {
   url: string;
   stars: number;
   forks: number;
+  watchers_count: number;
   language: string;
   owner: {
     login: string;
@@ -41,7 +42,6 @@ const RepositoryGrid = ({
   const [sortBy, setSortBy] = useState<"stars" | "forks" | "updated">("stars");
   const [filterLanguage, setFilterLanguage] = useState<string>("");
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const [minStars, setMinStars] = useState<number>(0);
 
   // Default repositories for display when none are provided
   const defaultRepositories: Repository[] = [
@@ -154,8 +154,7 @@ const RepositoryGrid = ({
       ? repo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
         repo.description.toLowerCase().includes(searchTerm.toLowerCase())
       : true;
-    const matchesStars = repo.stars >= minStars;
-    return matchesLanguage && matchesSearch && matchesStars;
+    return matchesLanguage && matchesSearch;
   });
 
   // Get unique languages for filter dropdown
@@ -209,26 +208,11 @@ const RepositoryGrid = ({
               />
             </div>
 
-            <div className="relative">
-              <Star className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-              <Input
-                type="number"
-                placeholder="Min stars"
-                value={minStars || ""}
-                onChange={(e) =>
-                  setMinStars(Math.max(0, parseInt(e.target.value) || 0))
-                }
-                className="pl-8 w-[120px]"
-                min="0"
-              />
-            </div>
-
             <Button
               variant="outline"
               size="icon"
               onClick={() => {
                 setSearchTerm("");
-                setMinStars(0);
               }}
             >
               <Filter className="h-4 w-4" />
@@ -265,7 +249,7 @@ const RepositoryGrid = ({
                 owner: repo.owner?.login || "",
                 stars: repo.stars || 0,
                 forks: repo.forks || 0,
-                watchers: 0, // Default value since it's not in the Repository interface
+                watchers: repo.watchers_count || 0,
                 language: repo.language || "Unknown",
                 readmeUrl: `${repo.url}/blob/main/README.md` || "",
                 avatarUrl: repo.owner?.avatar_url,

--- a/src/components/SearchInterface.tsx
+++ b/src/components/SearchInterface.tsx
@@ -135,6 +135,7 @@ const SearchInterface = ({
                 className="flex-1 md:flex-none"
                 disabled={isLoading}
               >
+                {isLoading && <RefreshCw className="h-4 w-4 mr-2 animate-spin" />}
                 Search
               </Button>
               <Button


### PR DESCRIPTION
This commit introduces several improvements to the GitHub Trending Explorer:

1.  **Display Watchers Count**: The "watchers" count for each repository is now correctly fetched and displayed on the repository cards. The data flow was corrected from `home.tsx` through `RepositoryGrid.tsx` to `RepositoryCard.tsx`.

2.  **Remove Redundant Filter**: The client-side "Minimum Stars" filter in the `RepositoryGrid` component has been removed. This filter was redundant as a more efficient API-level "Minimum Stars" filter already exists in the `SearchInterface`.

3.  **Enhanced Analysis Section**: The "Analysis" section on the `RepositoryCard` now includes the repository's creation date ("Created on {date}"). The default analysis text has also been updated to incorporate this information.

4.  **Improved UX**: A loading indicator (spinner icon) has been added to the main "Search" button in the `SearchInterface`, providing better visual feedback during API calls. This matches the behavior of the "Refresh" button.

These changes improve data presentation, reduce UI clutter, and enhance your experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Search" button now displays a spinning refresh icon while loading, providing clearer feedback during searches.

- **Improvements**
  - Repository cards now always show the repository creation date, along with language, star, and fork information. If available, analysis text is appended.
  - Repository watcher counts are now accurately displayed.

- **Removals**
  - The filter for minimum stars has been removed from the repository grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->